### PR TITLE
Introducing nullables / Creating a PdfClientSettings class

### DIFF
--- a/FastPDFService/FastPDFService.csproj
+++ b/FastPDFService/FastPDFService.csproj
@@ -18,6 +18,7 @@
 
 
     <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -28,7 +29,7 @@
     <PackageReference Include="Mime-Detective" Version="23.10.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <None Include="README.md" Pack="true" PackagePath="" />
-     <None Include="ressources/icon.png" Pack="true" PackagePath=""/>
+     <None Include="ressources/icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/FastPDFService/Models/ImageFile.cs
+++ b/FastPDFService/Models/ImageFile.cs
@@ -28,27 +28,27 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the format of the image file.
         /// </summary>
-        public string Format { get; set; }
+        public string? Format { get; set; }
 
         /// <summary>
         /// Gets or sets the URI of the image file.
         /// </summary>
-        public string Uri { get; set; }
+        public string? Uri { get; set; }
 
         /// <summary>
         /// Gets or sets the description of the image file. Default is "fastpdf-csharp ImageFile".
         /// </summary>
-        public string Description { get; set; } = "fastpdf-csharp ImageFile";
+        public string? Description { get; set; } = "fastpdf-csharp ImageFile";
 
         /// <summary>
         /// Gets or sets the binary data of the image file.
         /// </summary>
-        public byte[] ImageFileData { get; set; }
+        public byte[]? ImageFileData { get; set; }
 
         /// <summary>
         /// Gets or sets the unique identifier of the image file.
         /// </summary>
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets an optional numerical value associated with the image file.
@@ -58,17 +58,17 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the timestamp of the image file.
         /// </summary>
-        public DateTime Timestamp { get; set; }
+        public DateTime? Timestamp { get; set; }
 
         /// <summary>
         /// Gets or sets the identifier of the template associated with the image file.
         /// </summary>
-        public string TemplateId { get; set; }
+        public string? TemplateId { get; set; }
 
         /// <summary>
         /// Gets or sets the filename of the image file.
         /// </summary>
-        public string Filename { get; set; }
+        public string? Filename { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageFile"/> class.
@@ -108,7 +108,7 @@ namespace FastPDFService.Models
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is ImageFile other)
             {
@@ -132,14 +132,16 @@ namespace FastPDFService.Models
             var hash2 = HashCode.Combine(TemplateId, Filename);
             return HashCode.Combine(hash1, hash2);
         }
-
+        
         /// <inheritdoc/>
         public override string ToString()
         {
+            var templateFileData = ImageFileData != null 
+                ? BitConverter.ToString(ImageFileData)[..Math.Min(20, ImageFileData.Length)] + "..." 
+                : "null";
             return $"ImageFile {{ Format = {Format}, Uri = {Uri}, Description = {Description}, " +
-                $"ImageFileData = [{(ImageFileData != null ? BitConverter.ToString(ImageFileData).Substring(0, Math.Min(20, ImageFileData.Length)) + "..." : "null")}], " +
-                $"Id = {Id}, Number = {Number}, Timestamp = {Timestamp}, TemplateId = {TemplateId}, Filename = {Filename} }}";
+                $"ImageFileData = [{templateFileData}], Id = {Id}, Number = {Number}, Timestamp = {Timestamp}, " +
+                $"TemplateId = {TemplateId}, Filename = {Filename} }}";
         }
-        
     }
 }

--- a/FastPDFService/Models/PdfClientSettings.cs
+++ b/FastPDFService/Models/PdfClientSettings.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Dynamic;
+
+namespace FastPDFService.Models;
+
+/// <summary>
+/// Represents settings for the FastPDFService client.
+/// </summary>
+public class PdfClientSettings
+{
+    /// <summary>
+    /// The base URL for the PDF service.
+    /// </summary>
+    public string BaseUrl { get; set; } = "https://data.fastpdfservice.com";
+    
+    /// <summary>
+    /// The version of the API to use.
+    /// </summary>
+    public string ApiVersion { get; set; } = "v1";
+    
+    /// <summary>
+    /// A list of supported image formats. Supported formats include
+    /// jpeg, png, gif, bmp, tiff, webp, svg, ico, pdf, psd, ai, eps,
+    /// cr2, nef, sr2, orf, rw2, dng, arw, and heic.
+    /// </summary>
+    public List<string> SupportedImageFormats { get; set; } = new()
+    {
+        "jpeg", "png", "gif", "bmp", "tiff", "webp", "svg", "ico", "pdf",
+        "psd", "ai", "eps", "cr2", "nef", "sr2", "orf", "rw2", "dng",
+        "arw", "heic"
+    };
+
+    /// <summary>
+    /// A list of supported barcode formats. Supported formats include
+    /// codabar, code128, code39, ean, ean13, ean13-guard, ean14, ean8,
+    /// ean8-guard, gs1, gs1_128, gtin, isbn, isbn10, isbn13, issn, itf, jan,
+    /// nw-7, pzn, upc, upca.
+    /// </summary>
+    public List<string> SupportedBarcodeFormats { get; set; } = new()
+    {
+        "codabar", "code128", "code39", "ean", "ean13", "ean13-guard",
+        "ean14", "ean8", "ean8-guard", "gs1", "gs1_128", "gtin", "isbn",
+        "isbn10", "isbn13", "issn", "itf", "jan", "nw-7", "pzn", "upc",
+        "upca"
+    };
+}

--- a/FastPDFService/Models/RenderOptions.cs
+++ b/FastPDFService/Models/RenderOptions.cs
@@ -22,12 +22,12 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the templating engine to be used for rendering.
         /// </summary>
-        public string TemplatingEngine { get; set; }
+        public string? TemplatingEngine { get; set; }
 
         /// <summary>
         /// Gets or sets the rendering engine.
         /// </summary>
-        public string RenderingEngine { get; set; }
+        public string? RenderingEngine { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to display header and footer.
@@ -37,12 +37,12 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the byte array of the header file.
         /// </summary>
-        public byte[] HeaderFile { get; set; }
+        public byte[]? HeaderFile { get; set; }
 
         /// <summary>
         /// Gets or sets the byte array of the footer file.
         /// </summary>
-        public byte[] FooterFile { get; set; }
+        public byte[]? FooterFile { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the orientation is landscape.
@@ -52,7 +52,7 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the paper format (e.g., "A4", "Letter").
         /// </summary>
-        public string PaperFormat { get; set; }
+        public string? PaperFormat { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the background should be rendered.
@@ -62,7 +62,7 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the page range for rendering.
         /// </summary>
-        public string PageRange { get; set; }
+        public string? PageRange { get; set; }
 
         /// <summary>
         /// Gets or sets the scale for rendering.
@@ -147,7 +147,7 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the image mode for rendering.
         /// </summary>
-        public string ImageMode { get; set; }
+        public string? ImageMode { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether compression is enabled.
@@ -162,7 +162,7 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the background color in RGB format.
         /// </summary>
-        public int[] BackgroundColor { get; set; }
+        public int[]? BackgroundColor { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RenderOptions"/> class.
@@ -199,7 +199,7 @@ namespace FastPDFService.Models
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is RenderOptions other)
             {
@@ -275,15 +275,24 @@ namespace FastPDFService.Models
         /// <inheritdoc/>
         public override string ToString()
         {
+            var headerFile = HeaderFile != null 
+                ? BitConverter.ToString(HeaderFile)[..Math.Min(20, HeaderFile.Length)] + "..." 
+                : "null";
+            var footerFile = FooterFile != null 
+                ? BitConverter.ToString(FooterFile)[..Math.Min(20, FooterFile.Length)] + "..." 
+                : "null";
+            var backgroundColor = BackgroundColor != null ? string.Join(", ", BackgroundColor) : "null";
+            
             return $"RenderOptions {{ TemplatingEngine = {TemplatingEngine}, RenderingEngine = {RenderingEngine}, " +
-                $"DisplayHeaderFooter = {DisplayHeaderFooter}, HeaderFile = [{(HeaderFile != null ? BitConverter.ToString(HeaderFile).Substring(0, Math.Min(20, HeaderFile.Length)) + "..." : "null")}], " +
-                $"FooterFile = [{(FooterFile != null ? BitConverter.ToString(FooterFile).Substring(0, Math.Min(20, FooterFile.Length)) + "..." : "null")}], " +
-                $"Landscape = {Landscape}, PaperFormat = {PaperFormat}, Background = {Background}, PageRange = {PageRange}, " +
-                $"Scale = {Scale}, MarginTop = {MarginTop}, MarginRight = {MarginRight}, MarginBottom = {MarginBottom}, " +
-                $"MarginLeft = {MarginLeft}, PageNumberFooterEnabled = {PageNumberFooterEnabled}, TitleHeaderEnabled = {TitleHeaderEnabled}, " +
-                $"DateHeaderEnabled = {DateHeaderEnabled}, X = {X}, Y = {Y}, W = {W}, H = {H}, Width = {Width}, Height = {Height}, " +
-                $"KeepRatio = {KeepRatio}, TextEnabled = {TextEnabled}, ImageMode = {ImageMode}, Compress = {Compress}, " +
-                $"TransparencyEnabled = {TransparencyEnabled}, BackgroundColor = [{(BackgroundColor != null ? string.Join(", ", BackgroundColor) : "null")}] }}";
+                $"DisplayHeaderFooter = {DisplayHeaderFooter}, HeaderFile = [{headerFile}], " +
+                $"FooterFile = [{footerFile}], Landscape = {Landscape}, PaperFormat = {PaperFormat}, " +
+                $"Background = {Background}, PageRange = {PageRange}, Scale = {Scale}, MarginTop = {MarginTop}, " +
+                $"MarginRight = {MarginRight}, MarginBottom = {MarginBottom}, MarginLeft = {MarginLeft}, " +
+                $"PageNumberFooterEnabled = {PageNumberFooterEnabled}, TitleHeaderEnabled = {TitleHeaderEnabled}, " +
+                $"DateHeaderEnabled = {DateHeaderEnabled}, X = {X}, Y = {Y}, W = {W}, H = {H}, Width = {Width}, " +
+                $"Height = {Height}, KeepRatio = {KeepRatio}, TextEnabled = {TextEnabled}, ImageMode = {ImageMode}, " +
+                $"Compress = {Compress}, TransparencyEnabled = {TransparencyEnabled}, " +
+                $"BackgroundColor = [{backgroundColor}] }}";
         }
     }
 }

--- a/FastPDFService/Models/StyleFile.cs
+++ b/FastPDFService/Models/StyleFile.cs
@@ -27,22 +27,22 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the format of the stylesheet file. Default is "css".
         /// </summary>
-        public string Format { get; set; } = "css";
+        public string? Format { get; set; } = "css";
 
         /// <summary>
         /// Gets or sets the description of the stylesheet file. Default is "fastpdf-csharp StyleFile".
         /// </summary>
-        public string Description { get; set; } = "fastpdf-csharp StyleFile";
+        public string? Description { get; set; } = "fastpdf-csharp StyleFile";
 
         /// <summary>
         /// Gets or sets the binary data of the stylesheet file.
         /// </summary>
-        public byte[] StylesheetFile { get; set; }
+        public byte[]? StylesheetFile { get; set; }
 
         /// <summary>
         /// Gets or sets the unique identifier of the stylesheet file.
         /// </summary>
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets an optional numerical value associated with the stylesheet file.
@@ -52,17 +52,17 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the timestamp of the stylesheet file.
         /// </summary>
-        public DateTime Timestamp { get; set; }
+        public DateTime? Timestamp { get; set; }
 
         /// <summary>
         /// Gets or sets the identifier of the template associated with the stylesheet file.
         /// </summary>
-        public string TemplateId { get; set; }
+        public string? TemplateId { get; set; }
 
         /// <summary>
         /// Gets or sets the filename of the stylesheet file.
         /// </summary>
-        public string Filename { get; set; }
+        public string? Filename { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StyleFile"/> class.
@@ -90,7 +90,7 @@ namespace FastPDFService.Models
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is StyleFile other)
             {
@@ -117,9 +117,12 @@ namespace FastPDFService.Models
         /// <inheritdoc/>
         public override string ToString()
         {
+            var stylesheetFileString = StylesheetFile != null 
+                ? BitConverter.ToString(StylesheetFile)[..Math.Min(20, StylesheetFile.Length)] + "..." 
+                : "null";
             return $"StyleFile {{ Format = {Format}, Description = {Description}, " +
-                   $"StylesheetFile = [{(StylesheetFile != null ? BitConverter.ToString(StylesheetFile).Substring(0, Math.Min(20, StylesheetFile.Length)) + "..." : "null")}], " +
-                   $"Id = {Id}, Number = {Number}, Timestamp = {Timestamp}, TemplateId = {TemplateId}, Filename = {Filename} }}";
+                   $"StylesheetFile = [{stylesheetFileString}], Id = {Id}, Number = {Number}, " +
+                   $"Timestamp = {Timestamp}, TemplateId = {TemplateId}, Filename = {Filename} }}";
         }
     }
 }

--- a/FastPDFService/Models/Template.cs
+++ b/FastPDFService/Models/Template.cs
@@ -26,52 +26,52 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the name of the template.
         /// </summary>
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets the format of the template. Default is "html".
         /// </summary>
-        public string Format { get; set; } = "html";
+        public string? Format { get; set; } = "html";
 
         /// <summary>
         /// Gets or sets the description of the template. Default is "fastpdf-csharp Template".
         /// </summary>
-        public string Description { get; set; } = "fastpdf-csharp Template";
+        public string? Description { get; set; } = "fastpdf-csharp Template";
 
         /// <summary>
         /// Gets or sets the unique identifier of the template.
         /// </summary>
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the timestamp of the template.
         /// </summary>
-        public DateTime Timestamp { get; set; }
+        public DateTime? Timestamp { get; set; }
 
         /// <summary>
         /// Gets or sets the main template file.
         /// </summary>
-        public TemplateFile TemplateFile { get; set; }
+        public TemplateFile? TemplateFile { get; set; }
 
         /// <summary>
         /// Gets or sets the header file for the template.
         /// </summary>
-        public TemplateFile HeaderFile { get; set; }
+        public TemplateFile? HeaderFile { get; set; }
 
         /// <summary>
         /// Gets or sets the footer file for the template.
         /// </summary>
-        public TemplateFile FooterFile { get; set; }
+        public TemplateFile? FooterFile { get; set; }
 
         /// <summary>
         /// Gets or sets the array of image files associated with the template.
         /// </summary>
-        public ImageFile[] ImageFiles { get; set; }
+        public ImageFile[]? ImageFiles { get; set; }
 
         /// <summary>
         /// Gets or sets the array of stylesheet files associated with the template.
         /// </summary>
-        public StyleFile[] StyleFiles { get; set; }
+        public StyleFile[]? StyleFiles { get; set; }
 
         /// <summary>
         /// Gets or sets whether the template should be rendered in landscape orientation.
@@ -81,7 +81,7 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the paper format for the template.
         /// </summary>
-        public string PaperFormat { get; set; }
+        public string? PaperFormat { get; set; }
 
         /// <summary>
         /// Gets or sets whether to print background graphics in the rendered document.
@@ -91,7 +91,7 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the page range for rendering. Defines specific pages or ranges to render.
         /// </summary>
-        public string PageRange { get; set; }
+        public string? PageRange { get; set; }
 
         /// <summary>
         /// Gets or sets the scale factor for rendering the template.
@@ -176,7 +176,7 @@ namespace FastPDFService.Models
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is Template other)
             {

--- a/FastPDFService/Models/TemplateFile.cs
+++ b/FastPDFService/Models/TemplateFile.cs
@@ -21,11 +21,11 @@ namespace FastPDFService.Models
         /// <summary>
         /// Gets or sets the unique identifier of the template.
         /// </summary>
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is TemplateFile file && Id == file.Id;
         }

--- a/FastPDFService/PDFClient.cs
+++ b/FastPDFService/PDFClient.cs
@@ -38,50 +38,10 @@ namespace FastPDFService
     /// </summary>
     public class PDFClient
     {
-        private readonly HttpClient httpClient;
-        private readonly string apiKey;
-        private readonly string apiVersion;
-        private readonly string baseUrl;
-
-        private readonly ContentInspector inspector;
-
-        /// <summary>
-        /// A list of supported image formats. Supported formats include
-        /// jpeg, png, gif, bmp, tiff, webp, svg, ico, pdf, psd, ai, eps,
-        /// cr2, nef, sr2, orf, rw2, dng, arw, and heic.
-        /// </summary>
-        public List<string> SupportedImageFormats { get; private set; }
-
-        /// <summary>
-        /// A list of supported barcode formats. Supported formats include
-        /// codabar, code128, code39, ean, ean13, ean13-guard, ean14, ean8,
-        /// ean8-guard, gs1, gs1_128, gtin, isbn, isbn10, isbn13, issn, itf, jan,
-        /// nw-7, pzn, upc, upca.
-        /// </summary>
-        public List<string> SupportedBarcodeFormats { get; private set; }
-
-
-        /// <summary>
-        /// Constructs a PDFClient with the provided API key.
-        /// It uses the default base URL "https://data.fastpdfservice.com"
-        /// and default API version "v1".
-        /// </summary>
-        /// <param name="apiKey">The API key to authenticate requests.</param>
-        public PDFClient(string apiKey)
-            : this(apiKey, "https://data.fastpdfservice.com", "v1")
-        {
-        }
-
-        /// <summary>
-        /// Constructs a PDFClient with the provided API key and base URL.
-        /// It uses the default API version "v1".
-        /// </summary>
-        /// <param name="apiKey">The API key to authenticate requests.</param>
-        /// <param name="baseUrl">The base URL for the PDF service.</param>
-        public PDFClient(string apiKey, string baseUrl)
-            : this(apiKey, baseUrl, "v1")
-        {
-        }
+        private readonly HttpClient _httpClient;
+        private readonly string _apiKey;
+        private readonly ContentInspector _inspector;
+        private readonly PdfClientSettings _settings = new();
 
         /// <summary>
         /// Constructs a PDFClient with the provided API key, base URL, and API version.
@@ -89,162 +49,27 @@ namespace FastPDFService
         /// <param name="apiKey">The API key to authenticate requests.</param>
         /// <param name="baseUrl">The base URL for the PDF service.</param>
         /// <param name="apiVersion">The version of the API to use.</param>
-        public PDFClient(string apiKey, string baseUrl, string apiVersion)
+        public PDFClient(string apiKey, string? baseUrl = null, string? apiVersion = null)
         {
-            this.apiKey = apiKey;
-            this.baseUrl = baseUrl.EndsWith("/") ? baseUrl + apiVersion : baseUrl + "/" + apiVersion;
-            this.apiVersion = apiVersion;
-            this.httpClient = new HttpClient();
-            this.inspector =  new ContentInspectorBuilder() {
+            _apiKey = apiKey;
+            if (!string.IsNullOrEmpty(baseUrl))
+            {
+                _settings.BaseUrl = baseUrl.EndsWith("/") ? baseUrl + apiVersion : baseUrl + "/" + apiVersion;
+            }
+            if (!string.IsNullOrEmpty(apiVersion))
+            {
+                _settings.ApiVersion = apiVersion;
+            }
+            _httpClient = new HttpClient();
+            _inspector =  new ContentInspectorBuilder
+            {
                 Definitions = MimeDetective.Definitions.Default.All()
             }.Build();
-
-            // Initialize supported formats
-            InitializeSupportedFormats();
 
             // Configure JSON serializer settings if needed
             ConfigureJsonSerializer();
         }
 
-        private void InitializeSupportedFormats()
-        {
-            SupportedImageFormats = new List<string>
-            {
-                "jpeg", "png", "gif", "bmp", "tiff", "webp", "svg", "ico", "pdf",
-                "psd", "ai", "eps", "cr2", "nef", "sr2", "orf", "rw2", "dng",
-                "arw", "heic"
-            };
-            SupportedBarcodeFormats = new List<string>
-            {
-                "codabar", "code128", "code39", "ean", "ean13", "ean13-guard",
-                "ean14", "ean8", "ean8-guard", "gs1", "gs1_128", "gtin", "isbn",
-                "isbn10", "isbn13", "issn", "itf", "jan", "nw-7", "pzn", "upc",
-                "upca"
-            };
-        }
-
-        private static void ConfigureJsonSerializer()
-        {
-            JsonSerializerSettings settings = new()
-            {
-                DateFormatHandling = DateFormatHandling.IsoDateFormat,
-                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
-                Formatting = Formatting.Indented
-            };
-            settings.Converters.Add(new StringEnumConverter());
-        }
-
-        private static ByteArrayContent GetPDFByteArray(byte[] data) {
-            var fileByteArrayContent = new ByteArrayContent(data);
-            fileByteArrayContent.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
-            return fileByteArrayContent;
-        }
-
-        private async Task<HttpResponseMessage> GetAsync(string url)
-        {
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            request.Headers.Authorization = new AuthenticationHeaderValue(apiKey);
-
-            HttpResponseMessage response = await httpClient.SendAsync(request);
-            await RaiseForStatusAsync(response);
-            return response;
-        }
-        
-        // Helper method for GET requests that expect a JSON response
-        private async Task<T> GetAsync<T>(string url)
-        {
-            HttpResponseMessage response = await GetAsync(url);
-            string jsonResponse = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<T>(jsonResponse);
-        }
-
-        // PostAsync is a helper method for making POST requests
-        private async Task<byte[]> PostAsync(string url, HttpContent content)
-        {
-            using var request = new HttpRequestMessage(HttpMethod.Post, url)
-            {
-                Content = content
-            };
-            request.Headers.Authorization = new AuthenticationHeaderValue(apiKey);
-
-            HttpResponseMessage response = await httpClient.SendAsync(request);
-            await RaiseForStatusAsync(response);
-            return await response.Content.ReadAsByteArrayAsync();
-        }
-
-        private async Task<string> PostAsyncString(string url, HttpContent content)
-        {
-            using var request = new HttpRequestMessage(HttpMethod.Post, url)
-            {
-                Content = content
-            };
-            request.Headers.Authorization = new AuthenticationHeaderValue(apiKey);
-
-            HttpResponseMessage response = await httpClient.SendAsync(request);
-            await RaiseForStatusAsync(response);
-            return await response.Content.ReadAsStringAsync();
-        }
-
-        private async Task<bool> DeleteAsync(string url)
-        {
-            using var request = new HttpRequestMessage(HttpMethod.Delete, url);
-            request.Headers.Authorization = new AuthenticationHeaderValue(apiKey);
-
-            HttpResponseMessage response = await httpClient.SendAsync(request);
-            await RaiseForStatusAsync(response);
-            return response.StatusCode == HttpStatusCode.NoContent;
-        }
-
-        private static async Task RaiseForStatusAsync(HttpResponseMessage response)
-        {
-            if (!response.IsSuccessStatusCode)
-            {
-                string responseBodyString = await response.Content.ReadAsStringAsync();
-                throw new PDFException((int)response.StatusCode, response.ReasonPhrase, responseBodyString);
-            }
-        }
-
-        private static HttpContent ReadFile(string filePath)
-        {
-            if (string.IsNullOrEmpty(filePath))
-                return null;
-
-            byte[] fileContent = File.ReadAllBytes(filePath);
-            // Specify MIME type manually or use a library for detection
-            return new ByteArrayContent(fileContent);
-        }
-
-        private static HttpContent ReadFile(byte[] fileContent)
-        {
-            if (fileContent == null)
-                return null;
-
-            // Specify MIME type manually or use a library for detection
-            return new ByteArrayContent(fileContent);
-        }
-
-        private static List<HttpContent> ReadFilesFromBytes(List<byte[]> fileContents)
-        {
-            var fileRequestContents = new List<HttpContent>();
-            foreach (var fileContent in fileContents)
-            {
-                fileRequestContents.Add(ReadFile(fileContent));
-            }
-            return fileRequestContents;
-        }
-
-        private static List<HttpContent> ReadFiles(List<string> filePaths)
-        {
-            var fileRequestContents = new List<HttpContent>();
-            foreach (var filePath in filePaths)
-            {
-                fileRequestContents.Add(ReadFile(filePath));
-            }
-            return fileRequestContents;
-        }
-
-        /* Public functions */
-        
         /// <summary>
         /// Saves the provided content to the specified file path.
         /// </summary>
@@ -280,17 +105,16 @@ namespace FastPDFService
         public List<byte[]> Extract(byte[] zipBytes)
         {
             var files = new List<byte[]>();
-            using (var zipStream = new MemoryStream(zipBytes))
-            using (var archive = new ZipArchive(zipStream))
+            using var zipStream = new MemoryStream(zipBytes);
+            using var archive = new ZipArchive(zipStream);
+            foreach (var entry in archive.Entries)
             {
-                foreach (var entry in archive.Entries)
-                {
-                    using var entryStream = entry.Open();
-                    using var outputStream = new MemoryStream();
-                    entryStream.CopyTo(outputStream);
-                    files.Add(outputStream.ToArray());
-                }
+                using var entryStream = entry.Open();
+                using var outputStream = new MemoryStream();
+                entryStream.CopyTo(outputStream);
+                files.Add(outputStream.ToArray());
             }
+
             return files;
         }
 
@@ -298,21 +122,21 @@ namespace FastPDFService
         /// Asynchronously extracts the files from the given zip file content.
         /// </summary>
         /// <param name="zipBytes">The content of the zip file.</param>
-        /// <returns>A Task representing the asynchronous operation, containing a list of byte arrays for the extracted files.</returns>
+        /// <returns>A Task representing the asynchronous operation, containing a list of byte arrays for the extracted
+        /// files.</returns>
         public async Task<List<byte[]>> ExtractAsync(byte[] zipBytes)
         {
             var files = new List<byte[]>();
-            using (var zipStream = new MemoryStream(zipBytes))
-            using (var archive = new ZipArchive(zipStream))
+            using var zipStream = new MemoryStream(zipBytes);
+            using var archive = new ZipArchive(zipStream);
+            foreach (var entry in archive.Entries)
             {
-                foreach (var entry in archive.Entries)
-                {
-                    using var entryStream = entry.Open();
-                    using var outputStream = new MemoryStream();
-                    await entryStream.CopyToAsync(outputStream);
-                    files.Add(outputStream.ToArray());
-                }
+                await using var entryStream = entry.Open();
+                using var outputStream = new MemoryStream();
+                await entryStream.CopyToAsync(outputStream);
+                files.Add(outputStream.ToArray());
             }
+
             return files;
         }
 
@@ -327,12 +151,12 @@ namespace FastPDFService
             using var archive = new ZipArchive(zipStream);
             foreach (var entry in archive.Entries)
             {
-                string completeFilePath = Path.Combine(outputPath, entry.FullName);
-                string directoryPath = Path.GetDirectoryName(completeFilePath);
+                var completeFilePath = Path.Combine(outputPath, entry.FullName);
+                var directoryPath = Path.GetDirectoryName(completeFilePath);
 
                 if (!Directory.Exists(directoryPath))
                 {
-                    Directory.CreateDirectory(directoryPath);
+                    Directory.CreateDirectory(directoryPath!);
                 }
 
                 using var fileStream = new FileStream(completeFilePath, FileMode.Create);
@@ -353,16 +177,16 @@ namespace FastPDFService
             using var archive = new ZipArchive(zipStream);
             foreach (var entry in archive.Entries)
             {
-                string completeFilePath = Path.Combine(outputPath, entry.FullName);
-                string directoryPath = Path.GetDirectoryName(completeFilePath);
+                var completeFilePath = Path.Combine(outputPath, entry.FullName);
+                var directoryPath = Path.GetDirectoryName(completeFilePath);
 
                 if (!Directory.Exists(directoryPath))
                 {
-                    Directory.CreateDirectory(directoryPath);
+                    Directory.CreateDirectory(directoryPath!);
                 }
 
-                using var fileStream = new FileStream(completeFilePath, FileMode.Create);
-                using var entryStream = entry.Open();
+                await using var fileStream = new FileStream(completeFilePath, FileMode.Create);
+                await using var entryStream = entry.Open();
                 await entryStream.CopyToAsync(fileStream);
             }
         }
@@ -375,7 +199,7 @@ namespace FastPDFService
         /// <returns>true if the token is valid, false otherwise.</returns>
         public async Task<bool> ValidateTokenAsync()
         {
-            HttpResponseMessage response = await GetAsync($"{baseUrl}/token");
+            var response = await GetAsync($"{_settings.BaseUrl}/token");
             return response.StatusCode == HttpStatusCode.OK;
         }
 
@@ -404,7 +228,7 @@ namespace FastPDFService
                 { GetPDFByteArray(fileContent), "file", "file.pdf" },
                 { new StringContent(JsonConvert.SerializeObject(splits)), "splits" }
             };
-            return await PostAsync($"{baseUrl}/pdf/split", content);
+            return await PostAsync($"{_settings.BaseUrl}/pdf/split", content);
         }
 
         /// <summary>
@@ -432,7 +256,7 @@ namespace FastPDFService
                 { GetPDFByteArray(fileContent), "file", "file.pdf" },
                 { new StringContent(JsonConvert.SerializeObject(metadata)), "metadata" }
             };
-            return await PostAsync($"{baseUrl}/pdf/metadata", content);
+            return await PostAsync($"{_settings.BaseUrl}/pdf/metadata", content);
         }
 
         /// <summary>
@@ -442,13 +266,13 @@ namespace FastPDFService
         /// <returns>A Task representing the asynchronous operation, containing a byte array of the merged PDF.</returns>
         public async Task<byte[]> MergeFromFilePathsAsync(List<string> filePaths)
         {
-            if (filePaths.Count < 2 || filePaths.Count > 100)
+            if (filePaths.Count is < 2 or > 100)
             {
                 throw new ArgumentException("The number of files to merge should be between 2 and 100.");
             }
 
             using var content = new MultipartFormDataContent();
-            for (int i = 0; i < filePaths.Count; i++)
+            for (var i = 0; i < filePaths.Count; i++)
             {
                 var fileBytes = await File.ReadAllBytesAsync(filePaths[i]);
                 content.Add(GetPDFByteArray(fileBytes), $"file{i}", "file.pdf");
@@ -464,28 +288,18 @@ namespace FastPDFService
         /// <returns>A Task representing the asynchronous operation, containing a byte array of the merged PDF.</returns>
         public async Task<byte[]> MergeFromBytesAsync(List<byte[]> fileContents)
         {
-            if (fileContents.Count < 2 || fileContents.Count > 100)
+            if (fileContents.Count is < 2 or > 100)
             {
                 throw new ArgumentException("The number of files to merge should be between 2 and 100.");
             }
 
             using var content = new MultipartFormDataContent();
-            for (int i = 0; i < fileContents.Count; i++)
+            for (var i = 0; i < fileContents.Count; i++)
             {
                 content.Add(GetPDFByteArray(fileContents[i]), $"file{i}", "file.pdf");
             }
 
             return await MergeAsync(content);
-        }
-
-        /// <summary>
-        /// Internal method to asynchronously merge multiple PDFs represented by the given MultipartFormDataContent into a single PDF.
-        /// </summary>
-        /// <param name="content">Multipart form data containing the PDFs to be merged.</param>
-        /// <returns>A Task representing the asynchronous operation, containing a byte array of the merged PDF.</returns>
-        private async Task<byte[]> MergeAsync(MultipartFormDataContent content)
-        {
-            return await PostAsync($"{baseUrl}/pdf/merge", content);
         }
 
         /// <summary>
@@ -516,7 +330,7 @@ namespace FastPDFService
                 { new StringContent(JsonConvert.SerializeObject(splits)), "splits" }
             };
 
-            return await PostAsync($"{baseUrl}/pdf/split-zip", content);
+            return await PostAsync($"{_settings.BaseUrl}/pdf/split-zip", content);
         }
 
         /// <summary>
@@ -540,16 +354,16 @@ namespace FastPDFService
         public async Task<byte[]> ToImageAsync(byte[] fileContent, string outputFormat)
         {
             outputFormat = outputFormat.ToLowerInvariant();
-            if (!SupportedImageFormats.Contains(outputFormat))
+            if (!_settings.SupportedImageFormats.Contains(outputFormat))
             {
-                throw new ArgumentException($"Unsupported output format. Must be one of: {string.Join(", ", SupportedImageFormats)}");
+                throw new ArgumentException($"Unsupported output format. Must be one of: {string.Join(", ", _settings.SupportedImageFormats)}");
             }
 
             using var content = new MultipartFormDataContent
             {
                 { GetPDFByteArray(fileContent), "file", "file.pdf" }
             };
-            return await PostAsync($"{baseUrl}/pdf/image/{outputFormat}", content);
+            return await PostAsync($"{_settings.BaseUrl}/pdf/image/{outputFormat}", content);
         }
 
         /// <summary>
@@ -558,7 +372,7 @@ namespace FastPDFService
         /// <param name="filePath">The path to the PDF file.</param>
         /// <param name="options">Optional compression options (e.g., remove duplicate images).</param>
         /// <returns>A Task representing the asynchronous operation, containing the byte array of the compressed file.</returns>
-        public async Task<byte[]> CompressAsync(string filePath, Dictionary<string, bool> options = null)
+        public async Task<byte[]> CompressAsync(string filePath, Dictionary<string, bool>? options = null)
         {
             var fileContent = await File.ReadAllBytesAsync(filePath);
             return await CompressAsync(fileContent, options);
@@ -570,7 +384,7 @@ namespace FastPDFService
         ///  <param name="fileContent">The PDF file to compress.</param>
         /// <param name="options">Optional compression options (e.g., remove duplicate images).</param>
         /// <returns>A Task representing the asynchronous operation, containing the byte array of the compressed file.</returns>
-        public async Task<byte[]> CompressAsync(byte[] fileContent, Dictionary<string, bool> options = null)
+        public async Task<byte[]> CompressAsync(byte[] fileContent, Dictionary<string, bool>? options = null)
         {
             using var content = new MultipartFormDataContent
             {
@@ -582,7 +396,7 @@ namespace FastPDFService
                 content.Add(new StringContent(JsonConvert.SerializeObject(options)), "options");
             }
 
-            return await PostAsync($"{baseUrl}/pdf/compress", content);
+            return await PostAsync($"{_settings.BaseUrl}/pdf/compress", content);
         }
 
         /// <summary>
@@ -597,7 +411,7 @@ namespace FastPDFService
                 { new StringContent(url), "url" }
             };
 
-            return await PostAsync($"{baseUrl}/pdf/url", content);
+            return await PostAsync($"{_settings.BaseUrl}/pdf/url", content);
         }
 
         /// <summary>
@@ -607,7 +421,10 @@ namespace FastPDFService
         /// <param name="barcodeFormat">The format of the barcode to render (default is "code128").</param>
         /// <param name="renderOptions">Optional rendering options.</param>
         /// <returns>A Task representing the asynchronous operation, containing the byte array of the barcode image.</returns>
-        public async Task<byte[]> RenderBarcodeAsync(string data, string barcodeFormat = "code128", RenderOptions renderOptions = null)
+        public async Task<byte[]> RenderBarcodeAsync(
+            string data, 
+            string barcodeFormat = "code128", 
+            RenderOptions? renderOptions = null)
         {
             var dataMap = new Dictionary<string, object>
             {
@@ -628,7 +445,7 @@ namespace FastPDFService
             var jsonContent = JsonConvert.SerializeObject(requestMap);
             var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
-            return await PostAsync($"{baseUrl}/render/barcode", content);
+            return await PostAsync($"{_settings.BaseUrl}/render/barcode", content);
         }
 
         /// <summary>
@@ -637,19 +454,13 @@ namespace FastPDFService
         /// <param name="filePath">The path to the image file.</param>
         /// <param name="renderOptions">Optional rendering options.</param>
         /// <returns>A Task representing the asynchronous operation, containing the byte array of the rendered image.</returns>
-        public async Task<byte[]> RenderImageAsync(string filePath, RenderOptions renderOptions = null)
+        public async Task<byte[]> RenderImageAsync(string filePath, RenderOptions? renderOptions = null)
         {
             var fileContent = await File.ReadAllBytesAsync(filePath);
             return await RenderImageAsync(fileContent, renderOptions);
         }
 
-        private string GetFileMimeType(byte[] fileContent) 
-        {
-            var mimeType = inspector.Inspect(fileContent).ByMimeType();
-            if (mimeType.Length == 0)
-                return "";
-            return mimeType[0].MimeType;
-        }
+        
 
         /// <summary>
         /// Asynchronously renders an image from a file path with optional rendering options.
@@ -657,19 +468,23 @@ namespace FastPDFService
         /// <param name="fileContent">The image file to render.</param>
         /// <param name="renderOptions">Optional rendering options.</param>
         /// <returns>A Task representing the asynchronous operation, containing the byte array of the rendered image.</returns>
-        public async Task<byte[]> RenderImageAsync(byte[] fileContent, RenderOptions renderOptions = null)
+        public async Task<byte[]> RenderImageAsync(byte[] fileContent, RenderOptions? renderOptions = null)
         {
             using var content = new MultipartFormDataContent();
             var fileByteArrayContent = new ByteArrayContent(fileContent);
             fileByteArrayContent.Headers.ContentType = new MediaTypeHeaderValue(GetFileMimeType(fileContent));
             content.Add(fileByteArrayContent, "image", "image");
 
-            if (renderOptions != null)
+            if (renderOptions == null)
             {
-                content.Add(new StringContent(JsonConvert.SerializeObject(renderOptions), Encoding.UTF8, "application/json"), "render_options"); // Adjust serialization if needed
+                return await PostAsync($"{_settings.BaseUrl}/render/img", content);
             }
+            
+            var serializedObject = JsonConvert.SerializeObject(renderOptions);
+            var stringContent = new StringContent(serializedObject, Encoding.UTF8, "application/json");
+            content.Add(stringContent, "render_options"); // Adjust serialization if needed
 
-            return await PostAsync($"{baseUrl}/render/img", content);
+            return await PostAsync($"{_settings.BaseUrl}/render/img", content);
         }
 
         /// <summary>
@@ -678,15 +493,17 @@ namespace FastPDFService
         /// <param name="imageId">The ID of the image to be rendered.</param>
         /// <param name="renderOptions">Optional rendering options.</param>
         /// <returns>A Task representing the asynchronous operation, containing the byte array of the rendered image.</returns>
-        public async Task<byte[]> RenderImageFromIdAsync(string imageId, RenderOptions renderOptions = null)
+        public async Task<byte[]> RenderImageFromIdAsync(string imageId, RenderOptions? renderOptions = null)
         {
             using var content = new MultipartFormDataContent();
             if (renderOptions != null)
             {
-                content.Add(new StringContent(JsonConvert.SerializeObject(renderOptions), Encoding.UTF8, "application/json"), "render_options"); // Adjust serialization if needed
+                var serializedObject = JsonConvert.SerializeObject(renderOptions);
+                var stringContent = new StringContent(serializedObject, Encoding.UTF8, "application/json");
+                content.Add(stringContent, "render_options"); // Adjust serialization if needed
             }
         
-            return await PostAsync($"{baseUrl}/img/{imageId}", content);
+            return await PostAsync($"{_settings.BaseUrl}/img/{imageId}", content);
         }
 
         /// <summary>
@@ -694,9 +511,9 @@ namespace FastPDFService
         /// </summary>
         /// <param name="limit">Optional maximum number of templates to retrieve.</param>
         /// <returns>A Task representing the asynchronous operation, containing a list of available templates.</returns>
-        public async Task<List<Template>> GetAllTemplatesAsync(int? limit = null)
+        public async Task<List<Template>?> GetAllTemplatesAsync(int? limit = null)
         {
-            var url = $"{baseUrl}/template";
+            var url = $"{_settings.BaseUrl}/template";
             if (limit.HasValue)
             {
                 url += $"?limit={limit.Value}";
@@ -710,9 +527,9 @@ namespace FastPDFService
         /// </summary>
         /// <param name="templateId">The ID of the template to retrieve.</param>
         /// <returns>A Task representing the asynchronous operation, containing the template associated with the given ID.</returns>
-        public async Task<Template> GetTemplateAsync(string templateId)
+        public async Task<Template?> GetTemplateAsync(string templateId)
         {
-            return await GetAsync<Template>($"{baseUrl}/template/{templateId}");
+            return await GetAsync<Template>($"{_settings.BaseUrl}/template/{templateId}");
         }
 
         /// <summary>
@@ -723,8 +540,11 @@ namespace FastPDFService
         /// <param name="headerFilePath">Optional path to the file containing the header HTML code.</param>
         /// <param name="footerFilePath">Optional path to the file containing the footer HTML code.</param>
         /// <returns>A Task representing the asynchronous operation, containing the newly created template.</returns>
-        public async Task<Template> AddTemplateAsync(string filePath, Template templateData, 
-            string headerFilePath = null, string footerFilePath = null)
+        public async Task<Template?> AddTemplateAsync(
+            string filePath, 
+            Template templateData, 
+            string? headerFilePath = null, 
+            string? footerFilePath = null)
         {
             using var fileContent = new StreamContent(File.OpenRead(filePath));
             using var headerContent = headerFilePath != null ? new StreamContent(File.OpenRead(headerFilePath)) : null;
@@ -734,7 +554,14 @@ namespace FastPDFService
             var headerFilename = headerFilePath != null ? Path.GetFileName(headerFilePath) : null;
             var footerFilename = footerFilePath != null ? Path.GetFileName(footerFilePath) : null;
 
-            return await AddTemplateAsync(fileContent, templateData, headerContent, footerContent, filename, headerFilename, footerFilename);
+            return await AddTemplateAsync(
+                fileContent, 
+                templateData, 
+                headerContent, 
+                footerContent, 
+                filename, 
+                headerFilename, 
+                footerFilename);
         }
 
         /// <summary>
@@ -745,43 +572,28 @@ namespace FastPDFService
         /// <param name="headerFileContent">Optional content of the HTML header.</param>
         /// <param name="footerFileContent">Optional content of the HTML footer.</param>
         /// <returns>A Task representing the asynchronous operation, containing the newly created template.</returns>
-        public async Task<Template> AddTemplateAsync(byte[] fileContent, Template templateData, 
-            byte[] headerFileContent = null, byte[] footerFileContent = null)
+        public async Task<Template?> AddTemplateAsync(
+            byte[] fileContent, 
+            Template templateData, 
+            byte[]? headerFileContent = null, 
+            byte[]? footerFileContent = null)
         {
             using var fileStreamContent = new ByteArrayContent(fileContent);
             using var headerStreamContent = headerFileContent != null ? new ByteArrayContent(headerFileContent) : null;
             using var footerStreamContent = footerFileContent != null ? new ByteArrayContent(footerFileContent) : null;
 
             var filename = "file." + templateData.Format;
-            var headerFilename = "header.html";
-            var footerFilename = "footer.html";
+            const string headerFilename = "header.html";
+            const string footerFilename = "footer.html";
 
-            return await AddTemplateAsync(fileStreamContent, templateData, headerStreamContent, 
-                                          footerStreamContent, filename, headerFilename, footerFilename);
-        }
-
-        private async Task<Template> AddTemplateAsync(HttpContent fileRequestBody, Template templateData, 
-            HttpContent headerDataBody, HttpContent footerDataBody, string filename, string headerFilename, string footerFilename)
-        {
-            using var content = new MultipartFormDataContent
-            {
-                { fileRequestBody, "file_data", filename }
-            };
-
-            if (headerDataBody != null)
-            {
-                content.Add(headerDataBody, "header_data", headerFilename);
-            }
-            if (footerDataBody != null)
-            {
-                content.Add(footerDataBody, "footer_data", footerFilename);
-            }
-
-            var templateJson = JsonConvert.SerializeObject(templateData);
-            content.Add(new StringContent(templateJson, Encoding.UTF8, "application/json"), "template_data");
-
-            var response = await PostAsyncString($"{baseUrl}/template", content);
-            return JsonConvert.DeserializeObject<Template>(response);
+            return await AddTemplateAsync(
+                fileStreamContent, 
+                templateData, 
+                headerStreamContent, 
+                footerStreamContent, 
+                filename, 
+                headerFilename, 
+                footerFilename);
         }
 
         /// <summary>
@@ -790,8 +602,9 @@ namespace FastPDFService
         /// <param name="templateId">The ID of the template to which the stylesheet will be added.</param>
         /// <param name="filePath">The path of the stylesheet file on the local filesystem.</param>
         /// <param name="styleFileData">The meta-data of the stylesheet file.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the StyleFile object of the newly added stylesheet.</returns>
-        public async Task<StyleFile> AddStylesheetAsync(string templateId, string filePath, StyleFile styleFileData)
+        /// <returns>A Task representing the asynchronous operation, containing the StyleFile object of the newly
+        /// added stylesheet.</returns>
+        public async Task<StyleFile?> AddStylesheetAsync(string templateId, string filePath, StyleFile styleFileData)
         {
             using var fileContent = new StreamContent(File.OpenRead(filePath));
             var filename = Path.GetFileName(filePath);
@@ -805,26 +618,14 @@ namespace FastPDFService
         /// <param name="templateId">The ID of the template to which the stylesheet will be added.</param>
         /// <param name="fileContent">The content of the file for the new stylesheet.</param>
         /// <param name="styleFileData">The meta-data of the stylesheet file.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the StyleFile object of the newly added stylesheet.</returns>
-        public async Task<StyleFile> AddStylesheetAsync(string templateId, byte[] fileContent, StyleFile styleFileData)
+        /// <returns>A Task representing the asynchronous operation, containing the StyleFile object of the newly added
+        /// stylesheet.</returns>
+        public async Task<StyleFile?> AddStylesheetAsync(string templateId, byte[] fileContent, StyleFile styleFileData)
         {
             using var fileStreamContent = new ByteArrayContent(fileContent);
             var filename = "file." + styleFileData.Format;
 
             return await AddStylesheetAsync(templateId, fileStreamContent, styleFileData, filename);
-        }
-
-        private async Task<StyleFile> AddStylesheetAsync(string templateId, HttpContent fileRequestBody, StyleFile styleFileData, string filename)
-        {
-            using var content = new MultipartFormDataContent
-            {
-                { fileRequestBody, "file_data", filename }
-            };
-            var styleFileJson = JsonConvert.SerializeObject(styleFileData);
-            content.Add(new StringContent(styleFileJson, Encoding.UTF8, "application/json"), "template_data");
-
-            var response = await PostAsyncString($"{baseUrl}/template/css/{templateId}", content);
-            return JsonConvert.DeserializeObject<StyleFile>(response);
         }
 
         /// <summary>
@@ -833,14 +634,16 @@ namespace FastPDFService
         /// <param name="templateId">The ID of the template to which the image will be added.</param>
         /// <param name="filePath">The path of the image file on the local filesystem.</param>
         /// <param name="imageFileData">The meta-data of the image file.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the ImageFile object of the newly added image.</returns>
-        public async Task<ImageFile> AddImageAsync(string templateId, string filePath, ImageFile imageFileData)
+        /// <returns>A Task representing the asynchronous operation, containing the ImageFile object of the newly added
+        /// image.</returns>
+        public async Task<ImageFile?> AddImageAsync(string templateId, string filePath, ImageFile imageFileData)
         {
             var fileContent = await File.ReadAllBytesAsync(filePath);
             var mimeType = GetFileMimeType(fileContent);
             var filename = Path.GetFileName(filePath);
             using var fileStreamContent = new ByteArrayContent(fileContent);
-            fileStreamContent.Headers.ContentType = new MediaTypeHeaderValue(string.IsNullOrEmpty(mimeType) ? "application/octet-stream" : mimeType);
+            fileStreamContent.Headers.ContentType = new MediaTypeHeaderValue(
+                string.IsNullOrEmpty(mimeType) ? "application/octet-stream" : mimeType);
 
             return await AddImageAsync(templateId, fileStreamContent, imageFileData, filename);
         }
@@ -851,68 +654,61 @@ namespace FastPDFService
         /// <param name="templateId">The ID of the template to which the image will be added.</param>
         /// <param name="fileContent">The content of the file for the new image.</param>
         /// <param name="imageFileData">The meta-data of the image file.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the ImageFile object of the newly added image.</returns>
-        public async Task<ImageFile> AddImageAsync(string templateId, byte[] fileContent, ImageFile imageFileData)
+        /// <returns>A Task representing the asynchronous operation, containing the ImageFile object of the newly added
+        /// image.</returns>
+        public async Task<ImageFile?> AddImageAsync(string templateId, byte[] fileContent, ImageFile imageFileData)
         {
             var mimeType = GetFileMimeType(fileContent);
             var filename = "image." + imageFileData.Format;
             using var fileStreamContent = new ByteArrayContent(fileContent);
-            fileStreamContent.Headers.ContentType = new MediaTypeHeaderValue(string.IsNullOrEmpty(mimeType) ? "application/octet-stream" : mimeType);
+            fileStreamContent.Headers.ContentType = new MediaTypeHeaderValue(
+                string.IsNullOrEmpty(mimeType) ? "application/octet-stream" : mimeType);
 
             return await AddImageAsync(templateId, fileStreamContent, imageFileData, filename);
-        }
-
-        private async Task<ImageFile> AddImageAsync(string templateId, HttpContent fileRequestBody, ImageFile imageFileData, string filename)
-        {
-            using var content = new MultipartFormDataContent
-            {
-                { fileRequestBody, "file_data", filename }
-            };
-            var imageFileJson = JsonConvert.SerializeObject(imageFileData);
-            content.Add(new StringContent(imageFileJson, Encoding.UTF8, "application/json"), "template_data");
-
-            var response = await PostAsyncString($"{baseUrl}/template/img/{templateId}", content);
-            return JsonConvert.DeserializeObject<ImageFile>(response);
         }
 
         /// <summary>
         /// Asynchronously deletes a template.
         /// </summary>
         /// <param name="templateId">The ID of the template to be deleted.</param>
-        /// <returns>A Task representing the asynchronous operation, indicating whether the template was successfully deleted.</returns>
+        /// <returns>A Task representing the asynchronous operation, indicating whether the template was successfully
+        /// deleted.</returns>
         public async Task<bool> DeleteTemplateAsync(string templateId)
         {
-            return await DeleteAsync($"{baseUrl}/template/{templateId}");
+            return await DeleteAsync($"{_settings.BaseUrl}/template/{templateId}");
         }
 
         /// <summary>
         /// Asynchronously deletes a stylesheet.
         /// </summary>
         /// <param name="stylesheetId">The ID of the stylesheet to be deleted.</param>
-        /// <returns>A Task representing the asynchronous operation, indicating whether the stylesheet was successfully deleted.</returns>
+        /// <returns>A Task representing the asynchronous operation, indicating whether the stylesheet was successfully
+        /// deleted.</returns>
         public async Task<bool> DeleteStylesheetAsync(string stylesheetId)
         {
-            return await DeleteAsync($"{baseUrl}/template/css/{stylesheetId}");
+            return await DeleteAsync($"{_settings.BaseUrl}/template/css/{stylesheetId}");
         }
 
         /// <summary>
         /// Asynchronously deletes a image.
         /// </summary>
         /// <param name="imageId">The ID of the image to be deleted.</param>
-        /// <returns>A Task representing the asynchronous operation, indicating whether the image was successfully deleted.</returns>
+        /// <returns>A Task representing the asynchronous operation, indicating whether the image was successfully
+        /// deleted.</returns>
         public async Task<bool> DeleteImageAsync(string imageId)
         {
-            return await DeleteAsync($"{baseUrl}/template/img/{imageId}");
+            return await DeleteAsync($"{_settings.BaseUrl}/template/img/{imageId}");
         }
 
         /// <summary>
         /// Asynchronously retrieves the file of a template.
         /// </summary>
         /// <param name="templateId">The ID of the template whose file is to be retrieved.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the content of the template file as a byte array.</returns>
+        /// <returns>A Task representing the asynchronous operation, containing the content of the template file as a
+        /// byte array.</returns>
         public async Task<byte[]> GetTemplateFileAsync(string templateId)
         {
-            HttpResponseMessage response = await GetAsync($"{baseUrl}/template/file/{templateId}");
+            var response = await GetAsync($"{_settings.BaseUrl}/template/file/{templateId}");
             return await response.Content.ReadAsByteArrayAsync();
         }
 
@@ -920,10 +716,11 @@ namespace FastPDFService
         /// Asynchronously retrieves a stylesheet.
         /// </summary>
         /// <param name="stylesheetId">The ID of the stylesheet to be retrieved.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the content of the stylesheet as a byte array.</returns>
+        /// <returns>A Task representing the asynchronous operation, containing the content of the stylesheet as a byte
+        /// array.</returns>
         public async Task<byte[]> GetStylesheetAsync(string stylesheetId)
         {
-            HttpResponseMessage response = await GetAsync($"{baseUrl}/template/css/file/{stylesheetId}");
+            var response = await GetAsync($"{_settings.BaseUrl}/template/css/file/{stylesheetId}");
             return await response.Content.ReadAsByteArrayAsync();
         }
 
@@ -931,68 +728,12 @@ namespace FastPDFService
         /// Asynchronously retrieves an image.
         /// </summary>
         /// <param name="imageId">The ID of the image to be retrieved.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the content of the image as a byte array.</returns>
+        /// <returns>A Task representing the asynchronous operation, containing the content of the image as a byte
+        /// array.</returns>
         public async Task<byte[]> GetImageAsync(string imageId)
         {
-            HttpResponseMessage response = await GetAsync($"{baseUrl}/template/img/file/{imageId}");
+            var response = await GetAsync($"{_settings.BaseUrl}/template/img/file/{imageId}");
             return await response.Content.ReadAsByteArrayAsync();
-        }
-
-        private static Dictionary<string, object> ParseRenderDataObj(object obj)
-        {
-            if (obj is Dictionary<string, object> dictionary)
-            {
-                return dictionary;
-            }
-            else if (obj is string filePath)
-            {
-                string fileContent = File.ReadAllText(filePath);
-                return JsonConvert.DeserializeObject<Dictionary<string, object>>(fileContent);
-            }
-            else
-            {
-                throw new ArgumentException($"Expected Dictionary or String (file path). Unsupported render data type: {obj.GetType().Name}");
-            }
-        }
-
-        private static List<Dictionary<string, object>> ParseRenderDataList(object obj)
-        {
-            if (obj is List<Dictionary<string, object>> list)
-            {
-                return list;
-            }
-            else if (obj is string filePath)
-            {
-                string fileContent = File.ReadAllText(filePath);
-                return JsonConvert.DeserializeObject<List<Dictionary<string, object>>>(fileContent);
-            }
-            else
-            {
-                throw new ArgumentException($"Expected List or String (file path). Unsupported render data type: {obj.GetType().Name}");
-            }
-        }
-
-        private static async Task<Dictionary<string, object>> ParseRenderDataObjAsync(string path)
-        {
-            string fileContent = await File.ReadAllTextAsync(path);
-            return JsonConvert.DeserializeObject<Dictionary<string, object>>(fileContent);
-        }
-
-        private static async Task<List<Dictionary<string, object>>> ParseRenderDataListAsync(string path)
-        {
-            string fileContent = await File.ReadAllTextAsync(path);
-            return JsonConvert.DeserializeObject<List<Dictionary<string, object>>>(fileContent);
-        }
-
-        private static async Task<byte[]> ReadFileAsync(string filePath)
-        {
-            return await File.ReadAllBytesAsync(filePath);
-        }
-
-        private async Task<ByteArrayContent> ReadFileAsHttpContentAsync(string filePath)
-        {
-            var fileContent = await ReadFileAsync(filePath);
-            return new ByteArrayContent(fileContent);
         }
 
         /// <summary>
@@ -1003,9 +744,13 @@ namespace FastPDFService
         /// <param name="renderDataPath">The file path of the render data.</param>
         /// <param name="renderOptions">The rendering options to use.</param>
         /// <param name="formatType">The output format type  (Optional, default to pdf).</param>
-        /// <returns>A Task representing the asynchronous operation, containing the byte array of the rendered template.</returns>
-        public async Task<byte[]> RenderTemplateAsync(string templateId, string renderDataPath, 
-        RenderOptions renderOptions = null, string formatType = "pdf")
+        /// <returns>A Task representing the asynchronous operation, containing the byte array of the rendered
+        /// template.</returns>
+        public async Task<byte[]> RenderTemplateAsync(
+            string templateId, 
+            string renderDataPath, 
+            RenderOptions? renderOptions = null, 
+            string formatType = "pdf")
         {
             var renderDataObj = ParseRenderDataObj(renderDataPath);
             return await RenderTemplateAsync(templateId, renderDataObj, renderOptions, formatType);
@@ -1020,8 +765,11 @@ namespace FastPDFService
         /// <param name="renderOptions">The rendering options to use.</param>
         /// <param name="formatType">The output format type  (Optional, default to pdf).</param>
         /// <returns>A Task representing the asynchronous operation, containing the byte array of the rendered template.</returns>
-        public async Task<byte[]> RenderTemplateAsync(string templateId, Dictionary<string, object> renderData, 
-        RenderOptions renderOptions = null, string formatType = "pdf")
+        public async Task<byte[]> RenderTemplateAsync(
+            string templateId, 
+            Dictionary<string, object>? renderData, 
+            RenderOptions? renderOptions = null, 
+            string formatType = "pdf")
         {
             using var content = new MultipartFormDataContent();
             var renderDataJson = JsonConvert.SerializeObject(renderData);
@@ -1034,34 +782,46 @@ namespace FastPDFService
             }
 
             formatType = formatType.ToLower();
-            return await PostAsync($"{baseUrl}/render/{formatType}/{templateId}", content);
+            return await PostAsync($"{_settings.BaseUrl}/render/{formatType}/{templateId}", content);
         }
 
         /// <summary>
-        /// Asynchronously renders multiple instances of a template with the provided render data and render options, and a specified format type.
+        /// Asynchronously renders multiple instances of a template with the provided render data and render options,
+        /// and a specified format type.
         /// </summary>
         /// <param name="templateId">The ID of the template to render.</param>
         /// <param name="renderDataPath">The file path of the render data.</param>
         /// <param name="renderOptions">The rendering options to use (Optional).</param>
         /// <param name="formatType">The output format type  (Optional, default to pdf).</param>
-        /// <returns>A Task representing the asynchronous operation, containing the byte array of the rendered templates.</returns>
-        public async Task<byte[]> RenderTemplateManyAsync(string templateId, string renderDataPath, 
-        RenderOptions renderOptions = null, string formatType = "pdf")
+        /// <returns>A Task representing the asynchronous operation, containing the byte array of the rendered
+        /// templates.</returns>
+        /// <throws>ArgumentException if the render data is not a list of dictionaries.</throws>
+        public async Task<byte[]> RenderTemplateManyAsync(
+            string templateId, 
+            string renderDataPath, 
+            RenderOptions? renderOptions = null, 
+            string formatType = "pdf")
         {
             var renderDataList = await ParseRenderDataListAsync(renderDataPath);
+            
             return await RenderTemplateManyAsync(templateId, renderDataList, renderOptions, formatType);
         }
 
         /// <summary>
-        /// Asynchronously renders multiple instances of a template with the provided render data and render options, and a specified format type.
+        /// Asynchronously renders multiple instances of a template with the provided render data and render options,
+        /// and a specified format type.
         /// </summary>
         /// <param name="templateId">The ID of the template to render.</param>
         /// <param name="renderDataList">The list of render data to use.</param>
         /// <param name="renderOptions">The rendering options to use (Optional).</param>
         /// <param name="formatType">The output format type (Optional, default to pdf).</param>
-        /// <returns>A Task representing the asynchronous operation, containing the byte array of the rendered templates.</returns>
-        public async Task<byte[]> RenderTemplateManyAsync(string templateId, List<Dictionary<string, object>> renderDataList, 
-        RenderOptions renderOptions = null, string formatType = "pdf")
+        /// <returns>A Task representing the asynchronous operation, containing the byte array of the rendered
+        /// templates.</returns>
+        public async Task<byte[]> RenderTemplateManyAsync(
+            string templateId, 
+            List<Dictionary<string, object>>? renderDataList, 
+            RenderOptions? renderOptions = null, 
+            string formatType = "pdf")
         {
             using var content = new MultipartFormDataContent();
             var renderDataJson = JsonConvert.SerializeObject(renderDataList);
@@ -1074,7 +834,7 @@ namespace FastPDFService
             }
 
             formatType = formatType.ToLower();
-            return await PostAsync($"{baseUrl}/render/{formatType}/batch/{templateId}", content);
+            return await PostAsync($"{_settings.BaseUrl}/render/{formatType}/batch/{templateId}", content);
         }
 
         /// <summary>
@@ -1087,26 +847,36 @@ namespace FastPDFService
         /// <param name="footerFilePath">The path of the footer file or null.</param>
         /// <param name="renderOptions">The options for rendering the template or null.</param>
         /// <param name="formatType">The type of the output format.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered template as a byte array.</returns>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered template as a byte
+        /// array.</returns>
         public async Task<byte[]> RenderAsync(
             string templateFilePath,
-            Template template = null,
-            object renderData = null,
-            string headerFilePath = null,
-            string footerFilePath = null,
-            RenderOptions renderOptions = null,
+            Template? template = null,
+            object? renderData = null,
+            string? headerFilePath = null,
+            string? footerFilePath = null,
+            RenderOptions? renderOptions = null,
             string formatType = "pdf")
         {
             // Parse render data if it's a string path
-            Dictionary<string, object> renderDataDict = renderData as Dictionary<string, object>
-                ?? (renderData is string renderDataPath ? await global::FastPDFService.PDFClient.ParseRenderDataObjAsync(renderDataPath) : new Dictionary<string, object>());
+            var renderDataDict = renderData as Dictionary<string, object>
+                                 ?? (renderData is string renderDataPath 
+                                     ? await ParseRenderDataObjAsync(renderDataPath) 
+                                     : new Dictionary<string, object>());
 
             // Read files as byte array content
             var templateFileBody = await ReadFileAsHttpContentAsync(templateFilePath);
             var headerFileBody = headerFilePath != null ? await ReadFileAsHttpContentAsync(headerFilePath) : null;
             var footerFileBody = footerFilePath != null ? await ReadFileAsHttpContentAsync(footerFilePath) : null;
 
-            return await RenderInternalAsync(templateFileBody, template, renderDataDict, headerFileBody, footerFileBody, formatType, renderOptions);
+            return await RenderInternalAsync(
+                templateFileBody, 
+                template, 
+                renderDataDict, 
+                headerFileBody, 
+                footerFileBody, 
+                formatType, 
+                renderOptions);
         }
 
         /// <summary>
@@ -1122,28 +892,632 @@ namespace FastPDFService
         /// <returns>A Task representing the asynchronous operation, containing the rendered template as a byte array.</returns>
         public async Task<byte[]> RenderAsync(
             byte[] templateFileContent,
-            Template template = null,
-            Dictionary<string, object> renderData = null,
-            byte[] headerFileContent = null,
-            byte[] footerFileContent = null,
-            RenderOptions renderOptions = null,
+            Template? template = null,
+            Dictionary<string, object>? renderData = null,
+            byte[]? headerFileContent = null,
+            byte[]? footerFileContent = null,
+            RenderOptions? renderOptions = null,
             string formatType = "pdf")
         {
             using var templateFileBody = new ByteArrayContent(templateFileContent);
-            ByteArrayContent headerFileBody = headerFileContent != null ? new ByteArrayContent(headerFileContent) : null;
-            ByteArrayContent footerFileBody = footerFileContent != null ? new ByteArrayContent(footerFileContent) : null;
+            var headerFileBody = headerFileContent != null ? new ByteArrayContent(headerFileContent) : null;
+            var footerFileBody = footerFileContent != null ? new ByteArrayContent(footerFileContent) : null;
 
-            return await RenderInternalAsync(templateFileBody, template, renderData, headerFileBody, footerFileBody, formatType, renderOptions);
+            return await RenderInternalAsync(
+                templateFileBody, 
+                template, 
+                renderData, 
+                headerFileBody, 
+                footerFileBody, 
+                formatType, 
+                renderOptions);
         }
 
+        /// <summary>
+        /// Asynchronously renders a PDF from a template file path with provided parameters.
+        /// </summary>
+        /// <param name="templateFilePath">The path of the template file.</param>
+        /// <param name="renderDataPath">The file path of the render data.</param>
+        /// <param name="headerFilePath">The path of the header file, if any.</param>
+        /// <param name="footerFilePath">The path of the footer file, if any.</param>
+        /// <param name="template">The template data, if any.</param>
+        /// <param name="renderOptions">The options for rendering the template.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered PDF as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderToPDFAsync(
+            string templateFilePath,
+            string? renderDataPath = null,
+            string? headerFilePath = null,
+            string? footerFilePath = null,
+            Template? template = null,
+            RenderOptions? renderOptions = null)
+        {
+            // Parse render data if it's a string path
+            var renderDataDict = string.IsNullOrEmpty(renderDataPath) 
+                ? new Dictionary<string, object>() 
+                : await ParseRenderDataObjAsync(renderDataPath);
+
+            // Read files as byte array content
+            var templateFileBody = await ReadFileAsHttpContentAsync(templateFilePath);
+            var headerFileBody = headerFilePath != null ? await ReadFileAsHttpContentAsync(headerFilePath) : null;
+            var footerFileBody = footerFilePath != null ? await ReadFileAsHttpContentAsync(footerFilePath) : null;
+
+            return await RenderInternalAsync(
+                templateFileBody, 
+                template, 
+                renderDataDict, 
+                headerFileBody, 
+                footerFileBody, 
+                "pdf", 
+                renderOptions);
+        }
+
+        /// <summary>
+        /// Asynchronously renders a PDF from a template file path with provided parameters.
+        /// </summary>
+        /// <param name="templateFileContent">The content of the template file.</param>
+        /// <param name="renderData">The data to be rendered in the template.</param>
+        /// <param name="headerFileContent">The content of the header file, if any.</param>
+        /// <param name="footerFileContent">The content of the footer file, if any.</param>
+        /// <param name="template">The template data, if any.</param>
+        /// <param name="renderOptions">The options for rendering the template.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered PDF as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderToPDFAsync(
+            byte[] templateFileContent,
+            Dictionary<string, object>? renderData = null,
+            byte[]? headerFileContent = null,
+            byte[]? footerFileContent = null,
+            Template? template = null,
+            RenderOptions? renderOptions = null)
+        {
+            renderData ??= new Dictionary<string, object>();
+            using var templateFileBody = new ByteArrayContent(templateFileContent);
+            var headerFileBody = headerFileContent != null ? new ByteArrayContent(headerFileContent) : null;
+            var footerFileBody = footerFileContent != null ? new ByteArrayContent(footerFileContent) : null;
+
+            return await RenderInternalAsync(
+                templateFileBody, 
+                template, 
+                renderData, 
+                headerFileBody, 
+                footerFileBody, 
+                "pdf", 
+                renderOptions);
+        }
+
+        /// <summary>
+        /// Asynchronously renders multiple instances of a template from its file path with provided parameters.
+        /// </summary>
+        /// <param name="templateFilePath">The path of the template file.</param>
+        /// <param name="template">The template data, if any.</param>
+        /// <param name="renderDataPath">The file path of the render data.</param>
+        /// <param name="formatType">The format type for the rendered output.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered templates as a
+        /// byte array.</returns>
+        public async Task<byte[]> RenderManyAsync(
+            string templateFilePath, 
+            Template? template = null,
+            string? renderDataPath = null, 
+            string formatType = "pdf")
+        {
+            return await RenderManyAsync(templateFilePath, template, renderDataPath, null, null, null, formatType);
+        }
+
+        /// <summary>
+        /// Asynchronously renders multiple instances of a template from its file path with provided parameters.
+        /// </summary>
+        /// <param name="templateFilePath">The path of the template file.</param>
+        /// <param name="template">The template data, if any.</param>
+        /// <param name="renderDataPath">The file path of the render data.</param>
+        /// <param name="headerFilePath">The path of the header file, if any.</param>
+        /// <param name="footerFilePath">The path of the footer file, if any.</param>
+        /// <param name="formatType">The format type for the rendered output.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered templates as a byte
+        /// array.</returns>
+        public async Task<byte[]> RenderManyAsync(
+            string templateFilePath, 
+            Template? template = null,
+            string? renderDataPath = null, 
+            string? headerFilePath = null, 
+            string? footerFilePath = null,
+            string formatType = "pdf")
+        {
+            return await RenderManyAsync(
+                templateFilePath, 
+                template, 
+                renderDataPath, 
+                headerFilePath, 
+                footerFilePath, 
+                null, 
+                formatType);
+        }
+
+        /// <summary>
+        /// Asynchronously renders multiple instances of a template from its file path with provided parameters.
+        /// </summary>
+        /// <param name="templateFilePath">The path of the template file.</param>
+        /// <param name="template">The template data, if any.</param>
+        /// <param name="renderDataPath">The file path of the render data.</param>
+        /// <param name="headerFilePath">The path of the header file, if any.</param>
+        /// <param name="footerFilePath">The path of the footer file, if any.</param>
+        /// <param name="renderOptions">The options for rendering the template.</param>
+        /// <param name="formatType">The format type for the rendered output.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered templates as a byte array.</returns>
+        public async Task<byte[]> RenderManyAsync(
+            string templateFilePath, 
+            Template? template = null,
+            string? renderDataPath = null, 
+            string? headerFilePath = null, 
+            string? footerFilePath = null,
+            RenderOptions? renderOptions = null, 
+            string formatType = "pdf")
+        {
+            var templateFileContent = await ReadFileAsync(templateFilePath);
+            List<Dictionary<string, object>>? renderDataList = null;
+
+            if (!string.IsNullOrEmpty(renderDataPath))
+            {
+                renderDataList = await ParseRenderDataListAsync(renderDataPath);
+            }
+
+            byte[]? headerFileContent = null;
+            if (!string.IsNullOrEmpty(headerFilePath))
+            {
+                headerFileContent = await ReadFileAsync(headerFilePath);
+            }
+
+            byte[]? footerFileContent = null;
+            if (!string.IsNullOrEmpty(footerFilePath))
+            {
+                footerFileContent = await ReadFileAsync(footerFilePath);
+            }
+
+            return await RenderManyInternalAsync(
+                templateFileContent, 
+                template, 
+                renderDataList,
+                headerFileContent, 
+                footerFileContent, 
+                renderOptions, 
+                formatType);
+        }
+
+        /// <summary>
+        /// Asynchronously renders multiple instances of a template from its content with provided parameters.
+        /// </summary>
+        /// <param name="templateFileContent">The content of the template file.</param>
+        /// <param name="template">The template data, if any.</param>
+        /// <param name="renderDataList">The list of render data to be used.</param>
+        /// <param name="headerFileContent">The content of the header file, if any.</param>
+        /// <param name="footerFileContent">The content of the footer file, if any.</param>
+        /// <param name="renderOptions">The options for rendering the template.</param>
+        /// <param name="formatType">The format type for the rendered output.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered templates as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderManyAsync(
+            byte[] templateFileContent, 
+            Template? template = null,
+            List<Dictionary<string, object>>? renderDataList = null, 
+            byte[]? headerFileContent = null,
+            byte[]? footerFileContent = null, 
+            RenderOptions? renderOptions = null, 
+            string formatType = "pdf")
+        {
+            return await RenderManyInternalAsync(
+                templateFileContent, 
+                template, 
+                renderDataList,
+                headerFileContent, 
+                footerFileContent, 
+                renderOptions, 
+                formatType);
+        }
+
+        /// <summary>
+        /// Asynchronously renders multiple instances of a template from its file path with provided parameters.
+        /// </summary>
+        /// <param name="templateFilePath">The path of the template file.</param>
+        /// <param name="template">The template data, if any.</param>
+        /// <param name="renderDataList">The list of render data to be used.</param>
+        /// <param name="headerFilePath">The path of the header file, if any.</param>
+        /// <param name="footerFilePath">The path of the footer file, if any.</param>
+        /// <param name="formatType">The format type for the rendered output.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered templates as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderManyAsync(
+            string templateFilePath, 
+            Template? template = null,
+            List<Dictionary<string, object>>? renderDataList = null, 
+            string? headerFilePath = null, 
+            string? footerFilePath = null,
+            string formatType = "pdf")
+        {
+
+            var templateFileContent = await ReadFileAsync(templateFilePath);
+            byte[]? headerFileContent = null;
+            if (!string.IsNullOrEmpty(headerFilePath))
+            {
+                headerFileContent = await ReadFileAsync(headerFilePath);
+            }
+
+            byte[]? footerFileContent = null;
+            if (!string.IsNullOrEmpty(footerFilePath))
+            {
+                footerFileContent = await ReadFileAsync(footerFilePath);
+            }
+
+            return await RenderManyInternalAsync(templateFileContent, template, renderDataList, 
+            headerFileContent, footerFileContent, null, formatType);
+        }
+
+        /// <summary>
+        /// Asynchronously renders a template to a PDF format with provided render data.
+        /// </summary>
+        /// <param name="templateId">The ID of the template to be rendered.</param>
+        /// <param name="renderData">The data to be rendered in the template.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered PDF as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderTemplateToPdfAsync(string templateId, Dictionary<string, object>? renderData)
+        {
+            return await RenderTemplateAsync(templateId, renderData);
+        }
+
+        /// <summary>
+        /// Asynchronously renders a template to a DOCX format with provided render data.
+        /// </summary>
+        /// <param name="templateId">The ID of the template to be rendered.</param>
+        /// <param name="renderData">The data to be rendered in the template.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered DOCX as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderTemplateToDocxAsync(string templateId, Dictionary<string, object>? renderData)
+        {
+            return await RenderTemplateAsync(templateId, renderData, null, "docx");
+        }
+
+        /// <summary>
+        /// Asynchronously renders a template to a ODP format with provided render data.
+        /// </summary>
+        /// <param name="templateId">The ID of the template to be rendered.</param>
+        /// <param name="renderData">The data to be rendered in the template.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered ODP as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderTemplateToOdpAsync(string templateId, Dictionary<string, object>? renderData)
+        {
+            return await RenderTemplateAsync(templateId, renderData, null, "odp");
+        }
+
+        /// <summary>
+        /// Asynchronously renders a template to a ODS format with provided render data.
+        /// </summary>
+        /// <param name="templateId">The ID of the template to be rendered.</param>
+        /// <param name="renderData">The data to be rendered in the template.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered ODS as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderTemplateToOdsAsync(string templateId, Dictionary<string, object>? renderData)
+        {
+            return await RenderTemplateAsync(templateId, renderData, null, "ods");
+        }
+
+        /// <summary>
+        /// Asynchronously renders a template to a ODT format with provided render data.
+        /// </summary>
+        /// <param name="templateId">The ID of the template to be rendered.</param>
+        /// <param name="renderData">The data to be rendered in the template.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered ODT as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderTemplateToOdtAsync(string templateId, Dictionary<string, object>? renderData)
+        {
+            return await RenderTemplateAsync(templateId, renderData, null, "odt");
+        }
+
+        /// <summary>
+        /// Asynchronously renders a template to a PPTX format with provided render data.
+        /// </summary>
+        /// <param name="templateId">The ID of the template to be rendered.</param>
+        /// <param name="renderData">The data to be rendered in the template.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered PPTX as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderTemplateToPptxAsync(string templateId, Dictionary<string, object>? renderData)
+        {
+            return await RenderTemplateAsync(templateId, renderData, null, "pptx");
+        }
+
+        /// <summary>
+        /// Asynchronously renders a template to a XLX format with provided render data.
+        /// </summary>
+        /// <param name="templateId">The ID of the template to be rendered.</param>
+        /// <param name="renderData">The data to be rendered in the template.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered XLX as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderTemplateToXlxAsync(string templateId, Dictionary<string, object>? renderData)
+        {
+            return await RenderTemplateAsync(templateId, renderData, null, "xlx");
+        }
+
+        /// <summary>
+        /// Asynchronously renders a template to a XLS format with provided render data.
+        /// </summary>
+        /// <param name="templateId">The ID of the template to be rendered.</param>
+        /// <param name="renderData">The data to be rendered in the template.</param>
+        /// <returns>A Task representing the asynchronous operation, containing the rendered XLS as a byte array.
+        /// </returns>
+        public async Task<byte[]> RenderTemplateToXlsAsync(string templateId, Dictionary<string, object>? renderData)
+        {
+            return await RenderTemplateAsync(templateId, renderData, null, "xls");
+        }
+        
+        private static void ConfigureJsonSerializer()
+        {
+            JsonSerializerSettings settings = new()
+            {
+                DateFormatHandling = DateFormatHandling.IsoDateFormat,
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                Formatting = Formatting.Indented
+            };
+            settings.Converters.Add(new StringEnumConverter());
+        }
+
+        private static ByteArrayContent GetPDFByteArray(byte[] data) {
+            var fileByteArrayContent = new ByteArrayContent(data);
+            fileByteArrayContent.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+            return fileByteArrayContent;
+        }
+
+        private async Task<HttpResponseMessage> GetAsync(string url)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue(_apiKey);
+
+            var response = await _httpClient.SendAsync(request);
+            await RaiseForStatusAsync(response);
+            return response;
+        }
+        
+        // Helper method for GET requests that expect a JSON response
+        private async Task<T?> GetAsync<T>(string url)
+        {
+            var response = await GetAsync(url);
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<T>(jsonResponse);
+        }
+
+        // PostAsync is a helper method for making POST requests
+        private async Task<byte[]> PostAsync(string url, HttpContent content)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = content
+            };
+            request.Headers.Authorization = new AuthenticationHeaderValue(_apiKey);
+
+            var response = await _httpClient.SendAsync(request);
+            await RaiseForStatusAsync(response);
+            return await response.Content.ReadAsByteArrayAsync();
+        }
+
+        private async Task<string> PostAsyncString(string url, HttpContent content)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = content
+            };
+            request.Headers.Authorization = new AuthenticationHeaderValue(_apiKey);
+
+            var response = await _httpClient.SendAsync(request);
+            await RaiseForStatusAsync(response);
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        private async Task<bool> DeleteAsync(string url)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue(_apiKey);
+
+            var response = await _httpClient.SendAsync(request);
+            await RaiseForStatusAsync(response);
+            return response.StatusCode == HttpStatusCode.NoContent;
+        }
+
+        private static async Task RaiseForStatusAsync(HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseBodyString = await response.Content.ReadAsStringAsync();
+                throw new PDFException(
+                    (int)response.StatusCode, 
+                    response.ReasonPhrase ?? string.Empty, 
+                    responseBodyString);
+            }
+        }
+
+        private static HttpContent? ReadFile(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+                return null;
+
+            var fileContent = File.ReadAllBytes(filePath);
+            // Specify MIME type manually or use a library for detection
+            return new ByteArrayContent(fileContent);
+        }
+
+        private static HttpContent? ReadFile(byte[]? fileContent)
+        {
+            if (fileContent == null)
+                return null;
+
+            // Specify MIME type manually or use a library for detection
+            return new ByteArrayContent(fileContent);
+        }
+
+        private static List<HttpContent?> ReadFilesFromBytes(List<byte[]> fileContents)
+        {
+            var fileRequestContents = new List<HttpContent?>();
+            foreach (var fileContent in fileContents)
+            {
+                fileRequestContents.Add(ReadFile(fileContent));
+            }
+            return fileRequestContents;
+        }
+
+        private static List<HttpContent?> ReadFiles(List<string> filePaths)
+        {
+            var fileRequestContents = new List<HttpContent?>();
+            foreach (var filePath in filePaths)
+            {
+                fileRequestContents.Add(ReadFile(filePath));
+            }
+            return fileRequestContents;
+        }
+        
+        /// <summary>
+        /// Internal method to asynchronously merge multiple PDFs represented by the given MultipartFormDataContent
+        /// into a single PDF.
+        /// </summary>
+        /// <param name="content">Multipart form data containing the PDFs to be merged.</param>
+        /// <returns>A Task representing the asynchronous operation, containing a byte array of the merged PDF.</returns>
+        private async Task<byte[]> MergeAsync(HttpContent content)
+        {
+            return await PostAsync($"{_settings.BaseUrl}/pdf/merge", content);
+        }
+        
+        private string GetFileMimeType(byte[] fileContent) 
+        {
+            var mimeType = _inspector.Inspect(fileContent).ByMimeType();
+            if (mimeType.Length == 0)
+                return "";
+            return mimeType[0].MimeType;
+        }
+        
+        private async Task<Template?> AddTemplateAsync(
+            HttpContent fileRequestBody, 
+            Template templateData, 
+            HttpContent? headerDataBody, 
+            HttpContent? footerDataBody, 
+            string filename, 
+            string? headerFilename, 
+            string? footerFilename)
+        {
+            using var content = new MultipartFormDataContent
+            {
+                { fileRequestBody, "file_data", filename }
+            };
+
+            if (headerDataBody != null)
+            {
+                content.Add(headerDataBody, "header_data", headerFilename ?? string.Empty);
+            }
+            if (footerDataBody != null)
+            {
+                content.Add(footerDataBody, "footer_data", footerFilename ?? string.Empty);
+            }
+
+            var templateJson = JsonConvert.SerializeObject(templateData);
+            content.Add(new StringContent(templateJson, Encoding.UTF8, "application/json"), "template_data");
+
+            var response = await PostAsyncString($"{_settings.BaseUrl}/template", content);
+            
+            return JsonConvert.DeserializeObject<Template>(response);
+        }
+        
+        private async Task<StyleFile?> AddStylesheetAsync(
+            string templateId, 
+            HttpContent fileRequestBody, 
+            StyleFile styleFileData, 
+            string filename)
+        {
+            using var content = new MultipartFormDataContent
+            {
+                { fileRequestBody, "file_data", filename }
+            };
+            var styleFileJson = JsonConvert.SerializeObject(styleFileData);
+            content.Add(new StringContent(styleFileJson, Encoding.UTF8, "application/json"), "template_data");
+
+            var response = await PostAsyncString($"{_settings.BaseUrl}/template/css/{templateId}", content);
+            return JsonConvert.DeserializeObject<StyleFile>(response);
+        }
+        
+        private async Task<ImageFile?> AddImageAsync(
+            string templateId, 
+            HttpContent fileRequestBody, 
+            ImageFile imageFileData, 
+            string filename)
+        {
+            using var content = new MultipartFormDataContent
+            {
+                { fileRequestBody, "file_data", filename }
+            };
+            var imageFileJson = JsonConvert.SerializeObject(imageFileData);
+            content.Add(new StringContent(imageFileJson, Encoding.UTF8, "application/json"), "template_data");
+
+            var response = await PostAsyncString($"{_settings.BaseUrl}/template/img/{templateId}", content);
+            return JsonConvert.DeserializeObject<ImageFile>(response);
+        }
+        
+        private static Dictionary<string, object>? ParseRenderDataObj(object obj)
+        {
+            switch (obj)
+            {
+                case Dictionary<string, object> dictionary:
+                    return dictionary;
+                case string filePath:
+                {
+                    var fileContent = File.ReadAllText(filePath);
+                    return JsonConvert.DeserializeObject<Dictionary<string, object>>(fileContent);
+                }
+                default:
+                    throw new ArgumentException($"Expected Dictionary or String (file path). Unsupported render data type: {obj.GetType().Name}");
+            }
+        }
+
+        private static List<Dictionary<string, object>>? ParseRenderDataList(object obj)
+        {
+            switch (obj)
+            {
+                case List<Dictionary<string, object>> list:
+                    return list;
+                case string filePath:
+                {
+                    var fileContent = File.ReadAllText(filePath);
+                    return JsonConvert.DeserializeObject<List<Dictionary<string, object>>>(fileContent);
+                }
+                default:
+                    throw new ArgumentException("Expected List or String (file path). " +
+                                                $"Unsupported render data type: {obj.GetType().Name}");
+            }
+        }
+
+        private static async Task<Dictionary<string, object>?> ParseRenderDataObjAsync(string path)
+        {
+            var fileContent = await File.ReadAllTextAsync(path);
+            return JsonConvert.DeserializeObject<Dictionary<string, object>>(fileContent);
+        }
+
+        private static async Task<List<Dictionary<string, object>>?> ParseRenderDataListAsync(string path)
+        {
+            var fileContent = await File.ReadAllTextAsync(path);
+            return JsonConvert.DeserializeObject<List<Dictionary<string, object>>>(fileContent);
+        }
+
+        private static async Task<byte[]> ReadFileAsync(string filePath)
+        {
+            return await File.ReadAllBytesAsync(filePath);
+        }
+
+        private async Task<ByteArrayContent> ReadFileAsHttpContentAsync(string filePath)
+        {
+            var fileContent = await ReadFileAsync(filePath);
+            return new ByteArrayContent(fileContent);
+        }
+        
         private async Task<byte[]> RenderInternalAsync(
             ByteArrayContent templateFileContent,
-            Template template,
-            Dictionary<string, object> renderData,
-            ByteArrayContent headerFileContent = null,
-            ByteArrayContent footerFileContent = null,
+            Template? template,
+            Dictionary<string, object>? renderData,
+            ByteArrayContent? headerFileContent = null,
+            ByteArrayContent? footerFileContent = null,
             string formatType = "pdf",
-            RenderOptions renderOptions = null)
+            RenderOptions? renderOptions = null)
         {
             using var content = new MultipartFormDataContent
             {
@@ -1152,15 +1526,12 @@ namespace FastPDFService
             var renderDataJson = JsonConvert.SerializeObject(renderData);
             content.Add(new StringContent(renderDataJson, Encoding.UTF8, "application/json"), "render_data");
 
-            if (template == null)
+            template ??= new Template
             {
-                template = new Template
-                {
-                    Name = "fastpdf-java document",
-                    Format = "html",
-                    TitleHeaderEnabled = false
-                };
-            }
+                Name = "fastpdf-java document",
+                Format = "html",
+                TitleHeaderEnabled = false
+            };
             var templateJson = JsonConvert.SerializeObject(template);
             content.Add(new StringContent(templateJson, Encoding.UTF8, "application/json"), "template_data");
 
@@ -1178,213 +1549,33 @@ namespace FastPDFService
             }
 
             formatType = formatType.ToLower();
-            return await PostAsync($"{baseUrl}/render/{formatType}", content);
+            return await PostAsync($"{_settings.BaseUrl}/render/{formatType}", content);
         }
-
-        /// <summary>
-        /// Asynchronously renders a PDF from a template file path with provided parameters.
-        /// </summary>
-        /// <param name="templateFilePath">The path of the template file.</param>
-        /// <param name="renderDataPath">The file path of the render data.</param>
-        /// <param name="headerFilePath">The path of the header file, if any.</param>
-        /// <param name="footerFilePath">The path of the footer file, if any.</param>
-        /// <param name="template">The template data, if any.</param>
-        /// <param name="renderOptions">The options for rendering the template.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered PDF as a byte array.</returns>
-        public async Task<byte[]> RenderToPDFAsync(
-            string templateFilePath,
-            string renderDataPath = null,
-            string headerFilePath = null,
-            string footerFilePath = null,
-            Template template = null,
-            RenderOptions renderOptions = null)
-        {
-            // Parse render data if it's a string path
-            Dictionary<string, object> renderDataDict = string.IsNullOrEmpty(renderDataPath) 
-                ? new Dictionary<string, object>() 
-                : await ParseRenderDataObjAsync(renderDataPath);
-
-            // Read files as byte array content
-            var templateFileBody = await ReadFileAsHttpContentAsync(templateFilePath);
-            var headerFileBody = headerFilePath != null ? await ReadFileAsHttpContentAsync(headerFilePath) : null;
-            var footerFileBody = footerFilePath != null ? await ReadFileAsHttpContentAsync(footerFilePath) : null;
-
-            return await RenderInternalAsync(templateFileBody, template, renderDataDict, headerFileBody, footerFileBody, "pdf", renderOptions);
-        }
-
-        /// <summary>
-        /// Asynchronously renders a PDF from a template file path with provided parameters.
-        /// </summary>
-        /// <param name="templateFileContent">The content of the template file.</param>
-        /// <param name="renderData">The data to be rendered in the template.</param>
-        /// <param name="headerFileContent">The content of the header file, if any.</param>
-        /// <param name="footerFileContent">The content of the footer file, if any.</param>
-        /// <param name="template">The template data, if any.</param>
-        /// <param name="renderOptions">The options for rendering the template.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered PDF as a byte array.</returns>
-        public async Task<byte[]> RenderToPDFAsync(
-            byte[] templateFileContent,
-            Dictionary<string, object> renderData = null,
-            byte[] headerFileContent = null,
-            byte[] footerFileContent = null,
-            Template template = null,
-            RenderOptions renderOptions = null)
-        {
-
-            if (renderData == null) 
-            {
-                renderData = new Dictionary<string, object>();
-            }
-            using var templateFileBody = new ByteArrayContent(templateFileContent);
-            ByteArrayContent headerFileBody = headerFileContent != null ? new ByteArrayContent(headerFileContent) : null;
-            ByteArrayContent footerFileBody = footerFileContent != null ? new ByteArrayContent(footerFileContent) : null;
-
-            return await RenderInternalAsync(templateFileBody, template, renderData, headerFileBody, footerFileBody, "pdf", renderOptions);
-        }
-
-        /// <summary>
-        /// Asynchronously renders multiple instances of a template from its file path with provided parameters.
-        /// </summary>
-        /// <param name="templateFilePath">The path of the template file.</param>
-        /// <param name="template">The template data, if any.</param>
-        /// <param name="renderDataPath">The file path of the render data.</param>
-        /// <param name="formatType">The format type for the rendered output.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered templates as a byte array.</returns>
-        public async Task<byte[]> RenderManyAsync(string templateFilePath, Template template = null,
-            string renderDataPath = null, string formatType = "pdf")
-        {
-            return await RenderManyAsync(templateFilePath, template, renderDataPath, null, null, null, formatType);
-        }
-
-        /// <summary>
-        /// Asynchronously renders multiple instances of a template from its file path with provided parameters.
-        /// </summary>
-        /// <param name="templateFilePath">The path of the template file.</param>
-        /// <param name="template">The template data, if any.</param>
-        /// <param name="renderDataPath">The file path of the render data.</param>
-        /// <param name="headerFilePath">The path of the header file, if any.</param>
-        /// <param name="footerFilePath">The path of the footer file, if any.</param>
-        /// <param name="formatType">The format type for the rendered output.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered templates as a byte array.</returns>
-        public async Task<byte[]> RenderManyAsync(string templateFilePath, Template template = null,
-            string renderDataPath = null, string headerFilePath = null, string footerFilePath = null,
-            string formatType = "pdf")
-        {
-            return await RenderManyAsync(templateFilePath, template, renderDataPath, headerFilePath, footerFilePath, null, formatType);
-        }
-
-        /// <summary>
-        /// Asynchronously renders multiple instances of a template from its file path with provided parameters.
-        /// </summary>
-        /// <param name="templateFilePath">The path of the template file.</param>
-        /// <param name="template">The template data, if any.</param>
-        /// <param name="renderDataPath">The file path of the render data.</param>
-        /// <param name="headerFilePath">The path of the header file, if any.</param>
-        /// <param name="footerFilePath">The path of the footer file, if any.</param>
-        /// <param name="renderOptions">The options for rendering the template.</param>
-        /// <param name="formatType">The format type for the rendered output.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered templates as a byte array.</returns>
-        public async Task<byte[]> RenderManyAsync(string templateFilePath, Template template = null,
-            string renderDataPath = null, string headerFilePath = null, string footerFilePath = null,
-            RenderOptions renderOptions = null, string formatType = "pdf")
-        {
-            var templateFileContent = await ReadFileAsync(templateFilePath);
-            List<Dictionary<string, Object>> renderDataList = null;
-
-            if (!string.IsNullOrEmpty(renderDataPath))
-            {
-                renderDataList = await ParseRenderDataListAsync(renderDataPath);
-            }
-
-            byte[] headerFileContent = null;
-            if (!string.IsNullOrEmpty(headerFilePath))
-            {
-                headerFileContent = await ReadFileAsync(headerFilePath);
-            }
-
-            byte[] footerFileContent = null;
-            if (!string.IsNullOrEmpty(footerFilePath))
-            {
-                footerFileContent = await ReadFileAsync(footerFilePath);
-            }
-
-            return await RenderManyInternalAsync(templateFileContent, template, renderDataList,
-                headerFileContent, footerFileContent, renderOptions, formatType);
-        }
-
-        /// <summary>
-        /// Asynchronously renders multiple instances of a template from its content with provided parameters.
-        /// </summary>
-        /// <param name="templateFileContent">The content of the template file.</param>
-        /// <param name="template">The template data, if any.</param>
-        /// <param name="renderDataList">The list of render data to be used.</param>
-        /// <param name="headerFileContent">The content of the header file, if any.</param>
-        /// <param name="footerFileContent">The content of the footer file, if any.</param>
-        /// <param name="renderOptions">The options for rendering the template.</param>
-        /// <param name="formatType">The format type for the rendered output.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered templates as a byte array.</returns>
-        public async Task<byte[]> RenderManyAsync(byte[] templateFileContent, Template template = null,
-            List<Dictionary<string, Object>> renderDataList = null, byte[] headerFileContent = null,
-            byte[] footerFileContent = null, RenderOptions renderOptions = null, string formatType = "pdf")
-        {
-            return await RenderManyInternalAsync(templateFileContent, template, renderDataList,
-                headerFileContent, footerFileContent, renderOptions, formatType);
-        }
-
-        /// <summary>
-        /// Asynchronously renders multiple instances of a template from its file path with provided parameters.
-        /// </summary>
-        /// <param name="templateFilePath">The path of the template file.</param>
-        /// <param name="template">The template data, if any.</param>
-        /// <param name="renderDataList">The list of render data to be used.</param>
-        /// <param name="headerFilePath">The path of the header file, if any.</param>
-        /// <param name="footerFilePath">The path of the footer file, if any.</param>
-        /// <param name="formatType">The format type for the rendered output.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered templates as a byte array.</returns>
-        public async Task<byte[]> RenderManyAsync(string templateFilePath, Template template = null,
-            List<Dictionary<string, Object>> renderDataList = null, string headerFilePath = null, string footerFilePath = null,
-            string formatType = "pdf")
-        {
-
-            var templateFileContent = await ReadFileAsync(templateFilePath);
-            byte[] headerFileContent = null;
-            if (!string.IsNullOrEmpty(headerFilePath))
-            {
-                headerFileContent = await ReadFileAsync(headerFilePath);
-            }
-
-            byte[] footerFileContent = null;
-            if (!string.IsNullOrEmpty(footerFilePath))
-            {
-                footerFileContent = await ReadFileAsync(footerFilePath);
-            }
-
-            return await RenderManyInternalAsync(templateFileContent, template, renderDataList, 
-            headerFileContent, footerFileContent, null, formatType);
-        }
-
-        private async Task<byte[]> RenderManyInternalAsync(byte[] templateFileContent, Template templateData,
-            List<Dictionary<string, Object>> renderDataList, byte[] headerFileContent, byte[] footerFileContent,
-            RenderOptions renderOptions, string formatType)
+        
+        private async Task<byte[]> RenderManyInternalAsync(
+            byte[] templateFileContent, 
+            Template? templateData,
+            List<Dictionary<string, object>>? renderDataList, 
+            byte[]? headerFileContent, 
+            byte[]? footerFileContent,
+            RenderOptions? renderOptions, 
+            string formatType)
         {
             using var content = new MultipartFormDataContent
             {
                 { new ByteArrayContent(templateFileContent), "file_data", $"file.{templateData?.Format ?? "html"}" }
             };
 
-            if (templateData == null)
+            templateData ??= new Template
             {
-                templateData = new Template
-                {
-                    Name = "fastpdf-java document",
-                    Format = "html",
-                    TitleHeaderEnabled = false
-                };
-            }
-            var templateJson = JsonConvert.SerializeObject(templateData ?? new Template());
+                Name = "fastpdf-java document",
+                Format = "html",
+                TitleHeaderEnabled = false
+            };
+            var templateJson = JsonConvert.SerializeObject(templateData);
             content.Add(new StringContent(templateJson, Encoding.UTF8, "application/json"), "template_data");
 
-            var renderDataJson = JsonConvert.SerializeObject(renderDataList ?? new List<Dictionary<string, Object>>());
+            var renderDataJson = JsonConvert.SerializeObject(renderDataList ?? new List<Dictionary<string, object>>());
             content.Add(new StringContent(renderDataJson, Encoding.UTF8, "application/json"), "render_data");
 
             if (headerFileContent != null)
@@ -1404,97 +1595,8 @@ namespace FastPDFService
             }
 
             formatType = formatType.ToLowerInvariant();
-            var response = await PostAsync($"{baseUrl}/render/{formatType}/batch", content);
+            var response = await PostAsync($"{_settings.BaseUrl}/render/{formatType}/batch", content);
             return response;
         }
-
-        /// <summary>
-        /// Asynchronously renders a template to a PDF format with provided render data.
-        /// </summary>
-        /// <param name="templateId">The ID of the template to be rendered.</param>
-        /// <param name="renderData">The data to be rendered in the template.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered PDF as a byte array.</returns>
-        public async Task<byte[]> RenderTemplateToPdfAsync(string templateId, Dictionary<string, object> renderData)
-        {
-            return await RenderTemplateAsync(templateId, renderData, null, "pdf");
-        }
-
-        /// <summary>
-        /// Asynchronously renders a template to a DOCX format with provided render data.
-        /// </summary>
-        /// <param name="templateId">The ID of the template to be rendered.</param>
-        /// <param name="renderData">The data to be rendered in the template.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered DOCX as a byte array.</returns>
-        public async Task<byte[]> RenderTemplateToDocxAsync(string templateId, Dictionary<string, object> renderData)
-        {
-            return await RenderTemplateAsync(templateId, renderData, null, "docx");
-        }
-
-        /// <summary>
-        /// Asynchronously renders a template to a ODP format with provided render data.
-        /// </summary>
-        /// <param name="templateId">The ID of the template to be rendered.</param>
-        /// <param name="renderData">The data to be rendered in the template.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered ODP as a byte array.</returns>
-        public async Task<byte[]> RenderTemplateToOdpAsync(string templateId, Dictionary<string, object> renderData)
-        {
-            return await RenderTemplateAsync(templateId, renderData, null, "odp");
-        }
-
-        /// <summary>
-        /// Asynchronously renders a template to a ODS format with provided render data.
-        /// </summary>
-        /// <param name="templateId">The ID of the template to be rendered.</param>
-        /// <param name="renderData">The data to be rendered in the template.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered ODS as a byte array.</returns>
-        public async Task<byte[]> RenderTemplateToOdsAsync(string templateId, Dictionary<string, object> renderData)
-        {
-            return await RenderTemplateAsync(templateId, renderData, null, "ods");
-        }
-
-        /// <summary>
-        /// Asynchronously renders a template to a ODT format with provided render data.
-        /// </summary>
-        /// <param name="templateId">The ID of the template to be rendered.</param>
-        /// <param name="renderData">The data to be rendered in the template.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered ODT as a byte array.</returns>
-        public async Task<byte[]> RenderTemplateToOdtAsync(string templateId, Dictionary<string, object> renderData)
-        {
-            return await RenderTemplateAsync(templateId, renderData, null, "odt");
-        }
-
-        /// <summary>
-        /// Asynchronously renders a template to a PPTX format with provided render data.
-        /// </summary>
-        /// <param name="templateId">The ID of the template to be rendered.</param>
-        /// <param name="renderData">The data to be rendered in the template.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered PPTX as a byte array.</returns>
-        public async Task<byte[]> RenderTemplateToPptxAsync(string templateId, Dictionary<string, object> renderData)
-        {
-            return await RenderTemplateAsync(templateId, renderData, null, "pptx");
-        }
-
-        /// <summary>
-        /// Asynchronously renders a template to a XLX format with provided render data.
-        /// </summary>
-        /// <param name="templateId">The ID of the template to be rendered.</param>
-        /// <param name="renderData">The data to be rendered in the template.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered XLX as a byte array.</returns>
-        public async Task<byte[]> RenderTemplateToXlxAsync(string templateId, Dictionary<string, object> renderData)
-        {
-            return await RenderTemplateAsync(templateId, renderData, null, "xlx");
-        }
-
-        /// <summary>
-        /// Asynchronously renders a template to a XLS format with provided render data.
-        /// </summary>
-        /// <param name="templateId">The ID of the template to be rendered.</param>
-        /// <param name="renderData">The data to be rendered in the template.</param>
-        /// <returns>A Task representing the asynchronous operation, containing the rendered XLS as a byte array.</returns>
-        public async Task<byte[]> RenderTemplateToXlsAsync(string templateId, Dictionary<string, object> renderData)
-        {
-            return await RenderTemplateAsync(templateId, renderData, null, "xls");
-        }
-    
     }
 }


### PR DESCRIPTION
What I've changed:

    I've introduced nullable reference types into the project. I've tried to keep the logic as I found it. Basically, I just did a migration but it's possible that it broke some functionalities. We need to go back over the methods exposed to the user first and see if returning a nullable makes sense or not:
        if yes, it's handled
        if no, we need to change the return type of the method to non-nullable and put nullability checks in the other functions called in this method as needed.
        More info at https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references
    I've added a PdfClientSettings class that contains the default application settings. This can be useful later if we use a more classic architecture with an options pattern: https://learn.microsoft.com/en-us/dotnet/core/extensions/options

Potential improvements:

    This library will only be compatible with projects using .NET 6 or above. Consider remaking the library (or making a second one) in .NET Standard for backward compatibility with .NET Framework / .NET Standard / .NET Core projects https://dotnet.microsoft.com/en-us/platform/dotnet-standard
    The PdfClient class is 1600 lines long -> needs to be divided into smaller logical units. In the long term:
        in .NET 6: it should be a series of internal services (with utility methods, typically those that are private) and an external service that the developer can use with dependency injections.
        In .NET Standard: divide into a series of static classes (with utility methods, typically those that are private) according to the application logic and only leave in the client what is exposed to the developer while reducing the logic in the client methods (migrate it towards the static classes).